### PR TITLE
feat: build self-contained image for the release-tool

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -2,3 +2,11 @@ kind: common.Repository
 spec:
   conformLicenseCheck: false
   enableLicense: false
+---
+kind: common.Image
+name: image-release-tool
+spec:
+  baseImage: alpine:3.13
+  additionalImages: []
+  customCommands:
+    - apk add --no-cache git git-lfs make

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,11 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-03-15T12:21:30Z by kres 93ce485-dirty.
+# Generated on 2021-03-16T12:38:21Z by kres 9ef6cfd-dirty.
 
 ARG TOOLCHAIN
 
-FROM ghcr.io/talos-systems/ca-certificates:v0.3.0-12-g90722c3 AS image-ca-certificates
-
-FROM ghcr.io/talos-systems/fhs:v0.3.0-12-g90722c3 AS image-fhs
+FROM alpine:3.13 AS base-image-release-tool
 
 # runs markdownlint
 FROM node:14.8.0-alpine AS lint-markdown
@@ -77,9 +75,8 @@ COPY --from=release-tool-build /release-tool /release-tool
 FROM scratch AS unit-tests
 COPY --from=unit-tests-run /src/coverage.txt /coverage.txt
 
-FROM scratch AS image-release-tool
+FROM base-image-release-tool AS image-release-tool
+RUN apk add --no-cache git git-lfs make
 COPY --from=release-tool / /
-COPY --from=image-fhs / /
-COPY --from=image-ca-certificates / /
 ENTRYPOINT ["/release-tool"]
 

--- a/cmd/release-tool/main.go
+++ b/cmd/release-tool/main.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"text/tabwriter"
 	"text/template"
+	"time"
 	"unicode"
 
 	"github.com/pkg/errors"
@@ -82,6 +83,7 @@ type release struct { //nolint: govet
 	Preface         string            `toml:"preface"`
 	Notes           map[string]note   `toml:"notes"`
 	BreakingChanges map[string]change `toml:"breaking"`
+	ReleaseDate     string            `toml:"release_date"`
 
 	// dependency options
 	MatchDeps  string                    `toml:"match_deps"`
@@ -399,6 +401,10 @@ This tool should be ran from the root of the project repository for a new releas
 		r.Changes = projectChanges
 		r.Tag = tag
 		r.Version = version
+
+		if r.ReleaseDate == "" {
+			r.ReleaseDate = time.Now().UTC().Format("2006-01-02")
+		}
 
 		// Remove trailing new lines
 		r.Preface = strings.TrimRightFunc(r.Preface, unicode.IsSpace)

--- a/cmd/release-tool/template.go
+++ b/cmd/release-tool/template.go
@@ -18,7 +18,7 @@ package main
 
 const (
 	defaultTemplateFile = "TEMPLATE"
-	releaseNotes        = `{{.ProjectName}} {{.Version}}
+	releaseNotes        = `## [{{.ProjectName}} {{.Version}}](https://github.com/{{.GithubRepo}}/releases/tag/v{{.Version}}) ({{.ReleaseDate}})
 
 Welcome to the {{.Tag}} release of {{.ProjectName}}!
 {{- if .PreRelease }}  {{/* two spaces added for markdown newline*/}}


### PR DESCRIPTION
Now we can use `docker run` to generate the release notes without the
requirement to have _any_ tools on the host.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>