### PR TITLE
fix: don't generate changelog to previous if same as current

### DIFF
--- a/cmd/release-tool/main.go
+++ b/cmd/release-tool/main.go
@@ -232,7 +232,7 @@ This tool should be ran from the root of the project repository for a new releas
 			return err
 		}
 
-		if previousTag != "" && previousTag != r.Previous {
+		if previousTag != "" && previousTag != r.Previous && previousTag != r.Tag {
 			var previousTagChanges []change
 
 			previousTagChanges, err = changelog(previousTag, r.Commit)


### PR DESCRIPTION
This suppresses diff to previous tag if it's the first tag in the
release series (e.g. 0.10.0-alpha.0).

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>