### PR TITLE
feat: support (shorter) Github Flavored output

### DIFF
--- a/cmd/release-tool/main.go
+++ b/cmd/release-tool/main.go
@@ -134,6 +134,11 @@ This tool should be ran from the root of the project repository for a new releas
 			Aliases: []string{"l"},
 			Usage:   "add links to changelog",
 		},
+		&cli.BoolFlag{
+			Name:    "gfm",
+			Aliases: []string{"g"},
+			Usage:   "use GitHub Flavored Markdown links",
+		},
 		&cli.StringFlag{
 			Name:    "cache",
 			Usage:   "cache directory for static remote resources",
@@ -145,6 +150,7 @@ This tool should be ran from the root of the project repository for a new releas
 			releasePath = context.Args().First()
 			tag         = context.String("tag")
 			linkify     = context.Bool("linkify")
+			gfm         = context.Bool("gfm")
 		)
 
 		if tag == "" {
@@ -217,7 +223,7 @@ This tool should be ran from the root of the project repository for a new releas
 		}
 
 		if linkify {
-			if err = linkifyChanges(changes, githubCommitLink(r.GithubRepo), githubPRLink(r.GithubRepo)); err != nil {
+			if err = linkifyChanges(changes, githubCommitLink(r.GithubRepo, gfm), githubPRLink(r.GithubRepo), gfm); err != nil {
 				return err
 			}
 		}
@@ -241,7 +247,7 @@ This tool should be ran from the root of the project repository for a new releas
 			}
 
 			if linkify {
-				if err = linkifyChanges(previousTagChanges, githubCommitLink(r.GithubRepo), githubPRLink(r.GithubRepo)); err != nil {
+				if err = linkifyChanges(previousTagChanges, githubCommitLink(r.GithubRepo, gfm), githubPRLink(r.GithubRepo), gfm); err != nil {
 					return err
 				}
 			}
@@ -378,7 +384,7 @@ This tool should be ran from the root of the project repository for a new releas
 					} else {
 						ghname := dep.Name[11:]
 
-						if err = linkifyChanges(changes, githubCommitLink(ghname), githubPRLink(ghname)); err != nil {
+						if err = linkifyChanges(changes, githubCommitLink(ghname, gfm), githubPRLink(ghname), gfm); err != nil {
 							return err
 						}
 					}


### PR DESCRIPTION
This basically replaces full Markdown link like:

```
* [`64259fd0a`](https://github.com/talos-systems/talos/commit/64259fd0ad431a6ad475f36cd655f73295493e7d) fix: preserve PMBR bootable, align partitions with minimal I/O size
```

with a shorter one:

```
* talos-systems/talos@69ead373 fix: preserve PMBR bootable flag correctly
```

It only works via GitHub, but it's what we can use with GitHub release
notes to handle new 25000 bytes limit for the release notes.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>