### PR TITLE
fix: skip indirect go.mod deps

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,18 +1,18 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-03-15T12:21:30Z by kres 93ce485-dirty.
+# Generated on 2021-09-13T19:28:07Z by kres latest.
 
 codecov:
-require_ci_to_pass: false
+  require_ci_to_pass: false
 
 coverage:
-status:
-  project:
-    default:
-      target: 50%
-      threshold: 0.5%
-      base: auto
-      if_ci_failed: success
-  patch: off
+  status:
+    project:
+      default:
+        target: 50%
+        threshold: 0.5%
+        base: auto
+        if_ci_failed: success
+    patch: off
 
 comment: false

--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,12 +1,16 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-03-15T12:21:30Z by kres 93ce485-dirty.
+# Generated on 2021-09-13T19:30:04Z by kres latest.
 
+---
 policies:
 - type: commit
   spec:
     dco: true
-    gpg: false
+    gpg:
+      required: true
+      identity:
+        gitHubOrganization: talos-systems
     spellcheck:
       locale: US
     maximumOfOneCommit: true
@@ -19,4 +23,4 @@ policies:
       required: true
     conventional:
       types: ["chore","docs","perf","refactor","style","test","release"]
-      scopes: ["*"]
+      scopes: [".*"]

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-03-15T12:21:30Z by kres 93ce485-dirty.
+# Generated on 2021-09-13T19:28:07Z by kres latest.
 
 kind: pipeline
 type: kubernetes
@@ -216,9 +216,61 @@ steps:
   depends_on:
   - push-release-tool
 
+- name: release-notes
+  pull: always
+  image: autonomy/build-container:latest
+  commands:
+  - make release-notes
+  volumes:
+  - name: outer-docker-socket
+    path: /var/outer-run
+  - name: docker-socket
+    path: /var/run
+  - name: buildx
+    path: /root/.docker/buildx
+  - name: ssh
+    path: /root/.ssh
+  when:
+    event:
+    - tag
+  depends_on:
+  - unit-tests
+  - coverage
+  - release-tool
+  - image-release-tool
+  - lint
+
+- name: release
+  pull: always
+  image: plugins/github-release
+  settings:
+    api_key:
+      from_secret: github_token
+    checksum:
+    - sha256
+    - sha512
+    draft: true
+    files:
+    - _out/*
+    note: _out/RELEASE_NOTES.md
+  volumes:
+  - name: outer-docker-socket
+    path: /var/outer-run
+  - name: docker-socket
+    path: /var/run
+  - name: buildx
+    path: /root/.docker/buildx
+  - name: ssh
+    path: /root/.ssh
+  when:
+    event:
+    - tag
+  depends_on:
+  - release-notes
+
 services:
 - name: docker
-  image: docker:19.03-dind
+  image: docker:20.10-dind
   entrypoint:
   - dockerd
   commands:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-03-15T12:21:30Z by kres 93ce485-dirty.
-
+# Generated on 2021-09-13T19:28:07Z by kres latest.
 
 # options for analysis running
 run:
@@ -21,7 +20,6 @@ output:
   print-linter-name: true
   uniq-by-line: true
   path-prefix: ""
-
 
 # all available settings of specific linters
 linters-settings:
@@ -116,23 +114,30 @@ linters-settings:
 
 linters:
   enable-all: true
-  disable:
-    - gas
-    - typecheck
-    - gochecknoglobals
-    - gochecknoinits
-    - funlen
-    - godox
-    - gomnd
-    - goerr113
-    - nestif
-    - wrapcheck
-    - paralleltest
-    - exhaustivestruct
-    - forbidigo
   disable-all: false
   fast: false
-
+  disable:
+    - exhaustivestruct
+    - forbidigo
+    - funlen
+    - gas
+    - gochecknoglobals
+    - gochecknoinits
+    - godox
+    - goerr113
+    - gomnd
+    - gomoddirectives
+    - nestif
+    - paralleltest
+    - tagliatelle
+    - thelper
+    - typecheck
+    - wrapcheck
+    # abandoned linters for which golangci shows the warning that the repo is archived by the owner
+    - interfacer
+    - maligned
+    - golint
+    - scopelint
 
 issues:
   exclude: []
@@ -141,10 +146,8 @@ issues:
   exclude-case-sensitive: false
   max-issues-per-linter: 10
   max-same-issues: 3
-
   new: false
 
 severity:
   default-severity: error
-
   case-sensitive: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,14 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-03-16T12:38:21Z by kres 9ef6cfd-dirty.
+# Generated on 2021-09-13T19:30:04Z by kres latest.
 
 ARG TOOLCHAIN
 
 FROM alpine:3.13 AS base-image-release-tool
+
+# cleaned up specs and compiled versions
+FROM scratch AS generate
 
 # runs markdownlint
 FROM node:14.8.0-alpine AS lint-markdown
@@ -15,22 +18,20 @@ RUN npm i sentences-per-line@0.2.1
 WORKDIR /src
 COPY .markdownlint.json .
 COPY ./README.md ./README.md
-RUN markdownlint --ignore "**/node_modules/**" --ignore '**/hack/chglog/**' --rules /node_modules/sentences-per-line/index.js .
+RUN markdownlint --ignore "CHANGELOG.md" --ignore "**/node_modules/**" --ignore '**/hack/chglog/**' --rules /node_modules/sentences-per-line/index.js .
 
 # base toolchain image
 FROM ${TOOLCHAIN} AS toolchain
-RUN apk --update --no-cache add bash curl build-base
+RUN apk --update --no-cache add bash curl build-base protoc protobuf-dev
 
 # build tools
 FROM toolchain AS tools
 ENV GO111MODULE on
 ENV CGO_ENABLED 0
 ENV GOPATH /go
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /bin v1.38.0
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b /bin v1.42.1
 ARG GOFUMPT_VERSION
-RUN cd $(mktemp -d) \
-	&& go mod init tmp \
-	&& go get mvdan.cc/gofumpt/gofumports@${GOFUMPT_VERSION} \
+RUN go install mvdan.cc/gofumpt/gofumports@${GOFUMPT_VERSION} \
 	&& mv /go/bin/gofumports /bin/gofumports
 
 # tools and sources
@@ -46,6 +47,7 @@ RUN --mount=type=cache,target=/go/pkg go list -mod=readonly all >/dev/null
 # runs gofumpt
 FROM base AS lint-gofumpt
 RUN find . -name '*.pb.go' | xargs -r rm
+RUN find . -name '*.pb.gw.go' | xargs -r rm
 RUN FILES="$(gofumports -l -local github.com/containerd/release-tool .)" && test -z "${FILES}" || (echo -e "Source code is not formatted with 'gofumports -w -local github.com/containerd/release-tool .':\n${FILES}"; exit 1)
 
 # runs golangci-lint
@@ -54,10 +56,11 @@ COPY .golangci.yml .
 ENV GOGC 50
 RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/root/.cache/golangci-lint --mount=type=cache,target=/go/pkg golangci-lint run --config .golangci.yml
 
-# builds release-tool
-FROM base AS release-tool-build
+# builds release-tool-linux-amd64
+FROM base AS release-tool-linux-amd64-build
+COPY --from=generate / /
 WORKDIR /src/cmd/release-tool
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg go build -ldflags "-s -w" -o /release-tool
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg go build -ldflags "-s -w" -o /release-tool-linux-amd64
 
 # runs unit-tests with race detector
 FROM base AS unit-tests-race
@@ -67,16 +70,20 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/g
 # runs unit-tests
 FROM base AS unit-tests-run
 ARG TESTPKGS
-RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg --mount=type=cache,target=/tmp go test -v -covermode=atomic -coverprofile=coverage.txt -count 1 ${TESTPKGS}
+RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/go/pkg --mount=type=cache,target=/tmp go test -v -covermode=atomic -coverprofile=coverage.txt -coverpkg=${TESTPKGS} -count 1 ${TESTPKGS}
 
-FROM scratch AS release-tool
-COPY --from=release-tool-build /release-tool /release-tool
+FROM scratch AS release-tool-linux-amd64
+COPY --from=release-tool-linux-amd64-build /release-tool-linux-amd64 /release-tool-linux-amd64
 
 FROM scratch AS unit-tests
 COPY --from=unit-tests-run /src/coverage.txt /coverage.txt
 
+FROM release-tool-linux-${TARGETARCH} AS release-tool
+
 FROM base-image-release-tool AS image-release-tool
 RUN apk add --no-cache git git-lfs make
-COPY --from=release-tool / /
+ARG TARGETARCH
+COPY --from=release-tool release-tool-linux-${TARGETARCH} /release-tool
+LABEL org.opencontainers.image.source https://github.com/talos-systems/release-tool
 ENTRYPOINT ["/release-tool"]
 

--- a/cmd/release-tool/util.go
+++ b/cmd/release-tool/util.go
@@ -217,6 +217,10 @@ func parseGoModDependencies(r io.Reader) ([]dependency, error) {
 	replaceMap := make(map[string]*dependency)
 
 	for _, require := range goMod.Require {
+		if require.Indirect {
+			continue
+		}
+
 		commitOrVersion, isSha := getCommitOrVersion(require.Mod.Version)
 		if commitOrVersion == "" {
 			return nil, errors.Wrapf(errUnknownFormat, "poorly formatted version in require section %s", require.Mod)

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -2,16 +2,23 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-03-15T12:21:30Z by kres 93ce485-dirty.
+# Generated on 2021-09-13T19:28:07Z by kres latest.
 
+
+#!/bin/bash
 
 set -e
 
+RELEASE_TOOL_IMAGE="ghcr.io/talos-systems/release-tool:latest"
+
+function release-tool {
+  docker pull "${RELEASE_TOOL_IMAGE}" >/dev/null
+  docker run --rm -w /src -v "${PWD}":/src:ro "${RELEASE_TOOL_IMAGE}" -l -d -n -t "${1}" ./hack/release.toml
+}
+
 function changelog {
   if [ "$#" -eq 1 ]; then
-    git-chglog --output CHANGELOG.md -c ./hack/git-chglog/config.yaml --tag-filter-pattern "^${1}" "${1}.0-alpha.0.."
-  elif [ "$#" -eq 0 ]; then
-    git-chglog --output CHANGELOG.md -c ./hack/git-chglog/config.yaml
+    (release-tool ${1}; echo; cat CHANGELOG.md) > CHANGELOG.md- && mv CHANGELOG.md- CHANGELOG.md
   else
     echo 1>&2 "Usage: $0 changelog [tag]"
     exit 1
@@ -19,7 +26,7 @@ function changelog {
 }
 
 function release-notes {
-  git-chglog --output ${1} -c ./hack/git-chglog/config.yaml "${2}"
+  release-tool "${2}" > "${1}"
 }
 
 function cherry-pick {
@@ -51,9 +58,10 @@ then
 else
   cat <<EOF
 Usage:
-  commit:       Create the official release commit message.
-  cherry-pick:  Cherry-pick a commit into a release branch.
-  changelog:    Update the specified CHANGELOG.
+  commit:        Create the official release commit message.
+  cherry-pick:   Cherry-pick a commit into a release branch.
+  changelog:     Update the specified CHANGELOG.
+  release-notes: Create release notes for GitHub release.
 EOF
 
   exit 1

--- a/hack/release.toml
+++ b/hack/release.toml
@@ -1,0 +1,16 @@
+# THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
+#
+# Generated on 2021-09-13T19:28:07Z by kres latest.
+
+
+# commit to be tagged for the new release
+commit = "HEAD"
+
+project_name = "release-tool"
+github_repo = "containerd/release-tool"
+match_deps = "^github.com/(containerd/[a-zA-Z0-9-]+)$"
+
+# previous = -
+# pre_release = true
+
+# [notes]


### PR DESCRIPTION
With Go 1.17, go.mod has way too many indirect dependencies and we don't
need to push them to the release notes.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>