### PR TITLE
feat: handle repos without go.mod

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-03-23T19:45:28Z by kres latest.
+# Generated on 2022-04-25T14:05:08Z by kres 685be7b-dirty.
 
 # options for analysis running
 run:
@@ -39,6 +39,13 @@ linters-settings:
     local-prefixes: github.com/containerd/release-tool
   gocognit:
     min-complexity: 30
+  ireturn:
+    allow:
+      - anon
+      - error
+      - empty
+      - stdlib
+      - github.com\/talos-systems\/kres\/internal\/dag.Node
   nestif:
     min-complexity: 5
   goconst:
@@ -132,6 +139,7 @@ linters:
     - tagliatelle
     - thelper
     - typecheck
+    - varnamelen
     - wrapcheck
     # abandoned linters for which golangci shows the warning that the repo is archived by the owner
     - interfacer

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2022-03-23T19:45:28Z by kres latest.
+# Generated on 2022-04-25T14:05:08Z by kres 685be7b-dirty.
 
 # common variables
 
@@ -11,12 +11,13 @@ ARTIFACTS := _out
 REGISTRY ?= ghcr.io
 USERNAME ?= siderolabs
 REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
-GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6
-GO_VERSION ?= 1.17
-PROTOBUF_GO_VERSION ?= 1.27.1
-GRPC_GO_VERSION ?= 1.1.0
-GRPC_GATEWAY_VERSION ?= 2.4.0
-VTPROTOBUF_VERSION ?= 81d623a9a700ede8ef765e5ab08b3aa1f5b4d5a8
+GOFUMPT_VERSION ?= v0.3.1
+GO_VERSION ?= 1.18
+GOIMPORTS_VERSION ?= v0.1.10
+PROTOBUF_GO_VERSION ?= 1.28.0
+GRPC_GO_VERSION ?= 1.2.0
+GRPC_GATEWAY_VERSION ?= 2.10.0
+VTPROTOBUF_VERSION ?= 0.3.0
 TESTPKGS ?= ./...
 KRES_IMAGE ?= ghcr.io/siderolabs/kres:latest
 
@@ -37,12 +38,13 @@ COMMON_ARGS += --build-arg=TAG=$(TAG)
 COMMON_ARGS += --build-arg=USERNAME=$(USERNAME)
 COMMON_ARGS += --build-arg=TOOLCHAIN=$(TOOLCHAIN)
 COMMON_ARGS += --build-arg=GOFUMPT_VERSION=$(GOFUMPT_VERSION)
+COMMON_ARGS += --build-arg=GOIMPORTS_VERSION=$(GOIMPORTS_VERSION)
 COMMON_ARGS += --build-arg=PROTOBUF_GO_VERSION=$(PROTOBUF_GO_VERSION)
 COMMON_ARGS += --build-arg=GRPC_GO_VERSION=$(GRPC_GO_VERSION)
 COMMON_ARGS += --build-arg=GRPC_GATEWAY_VERSION=$(GRPC_GATEWAY_VERSION)
 COMMON_ARGS += --build-arg=VTPROTOBUF_VERSION=$(VTPROTOBUF_VERSION)
 COMMON_ARGS += --build-arg=TESTPKGS=$(TESTPKGS)
-TOOLCHAIN ?= docker.io/golang:1.17-alpine
+TOOLCHAIN ?= docker.io/golang:1.18-alpine
 
 # help menu
 
@@ -99,8 +101,11 @@ lint-gofumpt:  ## Runs gofumpt linter.
 fmt:  ## Formats the source code
 	@docker run --rm -it -v $(PWD):/src -w /src golang:$(GO_VERSION) \
 		bash -c "export GO111MODULE=on; export GOPROXY=https://proxy.golang.org; \
-		go install mvdan.cc/gofumpt/gofumports@$(GOFUMPT_VERSION) && \
-		gofumports -w -local github.com/containerd/release-tool ."
+		go install mvdan.cc/gofumpt@$(GOFUMPT_VERSION) && \
+		gofumpt -w ."
+
+lint-goimports:  ## Runs goimports linter.
+	@$(MAKE) target-$@
 
 .PHONY: base
 base:  ## Prepare base toolchain
@@ -133,7 +138,7 @@ lint-markdown:  ## Runs markdownlint.
 	@$(MAKE) target-$@
 
 .PHONY: lint
-lint: lint-golangci-lint lint-gofumpt lint-markdown  ## Run all linters for the project.
+lint: lint-golangci-lint lint-gofumpt lint-goimports lint-markdown  ## Run all linters for the project.
 
 .PHONY: image-release-tool
 image-release-tool:  ## Builds image for release-tool.

--- a/cmd/release-tool/main.go
+++ b/cmd/release-tool/main.go
@@ -100,7 +100,7 @@ type release struct { //nolint: govet
 	Downloads    []download
 }
 
-//nolint: gocognit, gocyclo, cyclop
+//nolint: gocognit, gocyclo, cyclop, maintidx
 func main() {
 	app := cli.NewApp()
 	app.Name = "release"

--- a/cmd/release-tool/util.go
+++ b/cmd/release-tool/util.go
@@ -156,7 +156,7 @@ func parseGoDependencies(commit string) ([]dependency, error) {
 		return parseGoModDependencies(rd)
 	}
 
-	return nil, errors.Errorf("finding dependency file failed: %v", err)
+	return nil, nil
 }
 
 func parseModulesTxtDependencies(r io.Reader) ([]dependency, error) {
@@ -422,6 +422,14 @@ func gitChangeDiff(previous, commit string) string {
 }
 
 func getChangelog(previous, commit string) ([]byte, error) {
+	// add current directory as 'safe' to git, as otherwise git complains about different user owning the repo files
+	// when run via `docker run -v`
+	if cwd, err := os.Getwd(); err == nil {
+		if _, err := git("config", "--global", "--add", "safe.directory", cwd); err != nil {
+			return nil, err
+		}
+	}
+
 	return git("log", "--oneline", gitChangeDiff(previous, commit))
 }
 


### PR DESCRIPTION
Allow to generate release notes for repos without go.mod file.

Workaround for new check in git to skip updating release.sh invocation.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>